### PR TITLE
Upgrade Play, ReactiveMongo and update the code

### DIFF
--- a/app/controllers/Articles.scala
+++ b/app/controllers/Articles.scala
@@ -19,7 +19,7 @@ import play.modules.reactivemongo.{
   MongoController, ReactiveMongoApi, ReactiveMongoComponents
 }
 
-import play.modules.reactivemongo.json._, ImplicitBSONHandlers._
+import play.modules.reactivemongo.json._
 import play.modules.reactivemongo.json.collection._
 
 import models.Article, Article._
@@ -61,7 +61,7 @@ class Articles @Inject() (
       flatMap(_.headOption).getOrElse("none")
 
     // the cursor of documents
-    val found = collection.find(query).cursor[Article]
+    val found = collection.find(query).cursor[Article]()
     // build (asynchronously) a list containing all the articles
     found.collect[List]().map { articles =>
       Ok(views.html.articles(articles, activeSort))

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ import play.PlayImport.PlayKeys._
 
 name := "reactivemongo-demo-app"
 
-version := "0.11.0"
+version := "0.11.1"
 
 scalaVersion := "2.11.6"
 
-libraryDependencies += "org.reactivemongo" %% "play2-reactivemongo" % "0.11.0.play24"
+libraryDependencies += "org.reactivemongo" %% "play2-reactivemongo" % "0.11.4.play24"
 
 routesGenerator := InjectedRoutesGenerator
 


### PR DESCRIPTION
- upgrade Play to version 2.4.2
- upgrade Play-ReactiveMongo to version 0.11.4.play24
- bump version of the project to 0.11.1
- suppress deprecation about cursor method
- remove the ImplicitBSONHandlers import to fix compilation errors:

```
[error] reactivemongo-demo-app/app/controllers/Articles.scala:64: No Json serializer as JsObject found for type play.api.libs.json.JsObject. Try to implement an implicit OWrites or OFormat for this type.
[error]     val found = collection.find(query).cursor[Article]
[error]                                ^
[error] reactivemongo-demo-app/app/controllers/Articles.scala:83: No Json serializer as JsObject found for type play.api.libs.json.JsObject. Try to implement an implicit OWrites or OFormat for this type.
[error]     val futureArticle = collection.find(Json.obj("_id" -> id)).one[Article]
[error]                                        ^
[error] reactivemongo-demo-app/app/controllers/Articles.scala:138: type mismatch;
[error]  found   : reactivemongo.bson.BSONDateTime
[error]  required: play.api.libs.json.Json.JsValueWrapper
[error]             "updateDate" -> BSONDateTime(new DateTime().getMillis),
[error]                                         ^
[error] reactivemongo-demo-app/app/controllers/Articles.scala:151: No Json serializer as JsObject found for type play.api.libs.json.JsObject. Try to implement an implicit OWrites or OFormat for this type.
[error]     gridFS.find[JsObject, JSONReadFile](Json.obj("article" -> id)).
[error]                                        ^
[error] reactivemongo-demo-app/app/controllers/Articles.scala:179: No Json serializer as JsObject found for type play.api.libs.json.JsObject. Try to implement an implicit OWrites or OFormat for this type.
[error]           gridFS.files.update(
[error]                              ^
[error] reactivemongo-demo-app/app/controllers/Articles.scala:194: No Json serializer as JsObject found for type play.api.libs.json.JsObject. Try to implement an implicit OWrites or OFormat for this type.
[error]     val file = gridFS.find[JsObject, JSONReadFile](Json.obj("_id" -> id))
[error]                                                   ^
[error] reactivemongo-demo-app/app/controllers/Articles.scala:205: No implicit view available from (String, play.api.libs.json.JsValue) => reactivemongo.bson.Producer[reactivemongo.bson.BSONElement].
[error]     gridFS.remove(Json toJson id).map(_ => Ok).
[error]                  ^
[error] 7 errors found
```

As a side note, here's probably the reason of the above problem and why removing the import fixes it:

```
reactivemongo-demo-app/app/controllers/Articles.scala:58: ambiguous implicit values:
[error]  both object JsValueWrites in trait DefaultWrites of type play.api.libs.json.Writes.JsValueWrites.type
[error]  and object JsObjectDocumentWriter in trait ImplicitBSONHandlers of type play.modules.reactivemongo.json.JsObjectDocumentWriter.type
[error]  match expected type play.api.libs.json.Writes[play.api.libs.json.JsObject]
```
